### PR TITLE
CI: Build and release pipeline using GitHub actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_style = space
 insert_final_newline = false
 max_line_length = 100
 tab_width = 4
+
+[{*.yaml,*.yml}]
+indent_size = 2

--- a/.github/workflows/build-and-release.md
+++ b/.github/workflows/build-and-release.md
@@ -1,0 +1,41 @@
+# Build and Release
+
+This pipeline is the one responsible for both building and creating a new release on Github. I felt the need to document the parameters, so in the future I don't have to dig into the pipeline code to understand what each one of them do.
+
+It was built with the intention of being used solely on the Github Web interface with no other triggers (i.e. new commits, new tags, etc), mainly because releases are usually very infrequent and also because manual releases are way more predictable.
+
+# Pipeline Parameters
+
+## 1. Build Mode
+
+There are some build mode, each one being useful in some situation, here follows a brief explanation of each one.
+
+- ### build and release
+
+The default build mode. It will build binaries for all OSes, then create a new release in Github. 
+
+In case the `tag` already exists, it'll be reused, which may lead to inaccurate `source-code.zip` in releases if there was a commit after the tag was created.   
+
+In case the `release` under the same `tag` already exists (release with same name), the binaries will be uploaded to this existing release. If the release already contains some of the files (matched by name and extension), they'll be overridden. Files that don't match the generated ones will not be deleted. The release note text will not be modified.
+
+- ### build and release (force) ⚠️
+
+A very aggressive build mode. It will build binaries for all OSes, then create a new release in Github. The difference between this and the previous is what it does with existing tags and releases.
+
+In case the `tag` already exists, it'll be **permanently deleted** together with **all releases** using the tag, so please **BE CAREFUL**!
+
+In case the `release` already exists (release with same name) but under a different `tag`, it won't be touched, a new `release` will be created under newly created tag. To make it clear: Github **allows** multiple releases with the same name to exist within the same project - they do not interfere with each other.
+
+- ### build only
+
+It will build binaries for all OSes, but not release any of them. Useful for cases where the binaries are needed but a new release is not.
+
+## 2. Version Tag
+
+By default, this pipeline will grab the version directly from `Cargo.toml`, but a different version may be specified to be used instead, which will override the `Cargo.toml` file one.
+
+When providing a custom version tag, be aware that a new commit updating the `Cargo.toml` version will **not** be created, and the program will *still* be built using the version in it. This custom version tag will *only* be used to create the Github tag and the release name. This option does nothing if the `Build Mode` is set to `build only`.
+
+## 3. Release Name
+
+The name used in the release. If not provided, the generated name will follow the pattern `v{version_tag}`. This option does nothing if the `Build Mode` is set to `build only`.

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,119 @@
+name: Build and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_mode:
+        description: Build mode
+        type: choice
+        required: true
+        default: build and release
+        options:
+          - build and release
+          - build and release (force)
+          - build only
+      version_tag:
+        description: Version tag (e.g. 1.2.5, empty to use the one defined in cargo.toml)
+        type: string
+        required: false
+      release_name:
+        description: Release name (e.g. v1.2.5, empty to generate one automatically)
+        type: string
+        required: false
+
+env:
+  CARGO_REGISTRY: https://github.com/rust-lang/crates.io-index
+  CARGO_TARGET_DIR: target
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      matrix:
+        target_toolchain:
+          - i686-pc-windows-msvc
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+    uses: ./.github/workflows/compile-for-os.yml
+    with:
+      target_toolchain: ${{ matrix.target_toolchain }}
+    secrets: inherit
+
+  release:
+    runs-on: ubuntu-latest
+    name: Release
+    needs: build
+    permissions:
+      contents: write
+    if: success() && (inputs.build_mode == 'build and release' || inputs.build_mode == 'build and release (force)')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: dist
+
+      - name: Move artifacts
+        run: |
+          mkdir -v -p dist-temp
+          for zip in dist/*/*.zip; do mv -v "$zip" dist-temp/; done
+          rm -r dist
+          mv -v dist-temp dist
+          find dist -type f -empty -print -delete -o -type d -empty -print -delete
+
+      - name: List dist folder contents
+        run: |
+          echo GitHub ref is: ${{ github.ref }}
+          echo === Current folder ===
+          pwd
+          echo === Root folder contents ===
+          ls -la
+          echo === Dist folder contents ===
+          ls -la dist
+
+      - name: Set version
+        id: version
+        run: |
+          version="${{ inputs.version_tag }}"
+          if [ -z "$version" ]; then
+            version=$(grep '^version =' Cargo.toml | awk '{print $3}' | tr -d '"')
+          fi
+          echo "New version is: $version"
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Set release name
+        id: release_name
+        run: |
+          release_name="${{ inputs.release_name }}"
+          if [ -z "$release_name" ]; then
+            release_name=v${{ steps.version.outputs.version }}
+          fi
+          echo "New release_name is: $release_name"
+          echo "release_name=$release_name" >> $GITHUB_OUTPUT
+
+      - name: Delete existing tag and release (only forced releases)
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        if: inputs.build_mode == 'build and release (force)'
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          delete_release: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.release_name.outputs.release_name }}
+          tag_name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            ./dist/ZipSource.x32.Windows.zip
+            ./dist/ZipSource.x64.Windows.zip
+            ./dist/ZipSource.x64.Linux.zip
+            ./dist/ZipSource.x64.MacOS.zip

--- a/.github/workflows/compile-for-os.yml
+++ b/.github/workflows/compile-for-os.yml
@@ -1,0 +1,181 @@
+name: Compile for OS
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_toolchain:
+        description: Select what rust toolchain to use
+        type: choice
+        required: true
+        default: x86_64-unknown-linux-gnu
+        options:
+          - i686-pc-windows-msvc
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+  workflow_call:
+    inputs:
+      target_toolchain:
+        description: Select what rust toolchain to use
+        type: string
+        required: true
+
+env:
+  CARGO_REGISTRY: https://github.com/rust-lang/crates.io-index
+  CARGO_TARGET_DIR: target
+  CARGO_TERM_COLOR: always
+
+jobs:
+  os_info:
+    runs-on: ubuntu-latest
+    name: Infer OS infos
+    outputs:
+      os_name: ${{ steps.os_name.outputs.os_name }}
+      os_name_pretty: ${{ steps.os_name_pretty.outputs.os_name_pretty }}
+      runs_on_os_name: ${{ steps.runs_on_os_name.outputs.runs_on_os_name }}
+      architecture_bits: ${{ steps.architecture_bits.outputs.architecture_bits }}
+    steps:
+      - name: Infer OS name
+        id: os_name
+        run: |
+          toolchain=$(echo "${{ inputs.target_toolchain }}" | tr '[:upper:]' '[:lower:]')
+          echo Toolchain: $toolchain
+          if [[ "$toolchain" = *-windows-* ]]; then
+            os_name=windows
+          elif [[ "$toolchain" = *-linux-* ]]; then
+            os_name=linux
+          elif [[ "$toolchain" = *-apple-darwin* ]]; then
+            os_name=macos
+          else 
+            echo Error: toolchain '${{ inputs.target_toolchain }}' has no corresponding OS mapped in the build pipeline.
+            exit 1
+          fi
+          echo OS inferred was: $os_name
+          echo "os_name=$os_name" >> $GITHUB_OUTPUT
+
+      - name: Infer pretty OS name
+        id: os_name_pretty
+        run: |
+          os_name=$(echo "${{ steps.os_name.outputs.os_name }}" | tr '[:upper:]' '[:lower:]')
+          echo OS name: $os_name
+          if [ "$os_name" = "windows" ]; then
+            os_name_pretty=Windows
+          elif [ "$os_name" = "linux" ]; then
+            os_name_pretty=Linux
+          elif [ "$os_name" = "macos" ]; then
+            os_name_pretty=MacOS
+          else
+            echo Error: OS $os_name has no corresponding pretty OS name mapped in the build pipeline.
+            exit 1
+          fi
+          echo Pretty OS inferred was: $os_name_pretty
+          echo "os_name_pretty=$os_name_pretty" >> $GITHUB_OUTPUT
+
+      - name: Infer runs on OS name
+        id: runs_on_os_name
+        run: |
+          os_name=$(echo "${{ steps.os_name.outputs.os_name }}" | tr '[:upper:]' '[:lower:]')
+          echo OS name: $os_name
+          if [ "$os_name" = "windows" ]; then
+            runs_on_os_name=windows-latest
+          elif [ "$os_name" = "linux" ]; then
+            runs_on_os_name=ubuntu-latest
+          elif [ "$os_name" = "macos" ]; then
+            runs_on_os_name=macos-latest
+          else 
+            echo Error: OS $os_name has no corresponding runs on os mapped in the build pipeline.
+            exit 1
+          fi
+          echo Runs on OS inferred was: $runs_on_os_name
+          echo "runs_on_os_name=$runs_on_os_name" >> $GITHUB_OUTPUT
+
+      - name: Infer architecture bits
+        id: architecture_bits
+        run: |
+          toolchain=$(echo "${{ inputs.target_toolchain }}" | tr '[:upper:]' '[:lower:]')
+          echo Toolchain: $toolchain
+          if [[ "$toolchain" == i686-* ]]; then
+            architecture_bits=x32
+          elif [[ "$toolchain" == x86_64-* ]]; then
+            architecture_bits=x64
+          elif [[ "$toolchain" == aarch64-* ]]; then
+            architecture_bits=Arm64
+          else
+            echo Error: toolchain '${{ inputs.target_toolchain }}' has no architecture mapped in the build pipeline.
+            exit 1
+          fi
+          echo Architecture inferred was: $architecture_bits
+          echo "architecture_bits=$architecture_bits" >> $GITHUB_OUTPUT
+  
+  build_variables:
+    runs-on: ubuntu-latest
+    name: Build variables
+    needs:
+      - os_info
+    outputs:
+      binary_name: ${{ steps.binary_name.outputs.binary_name }}
+      release_folder: ${{ steps.release_folder.outputs.release_folder }}
+    steps:
+      - name: Generate final binary name
+        id: binary_name
+        run: |
+          binary_name=$(echo ZipSource.${{ needs.os_info.outputs.architecture_bits }}.${{ needs.os_info.outputs.os_name_pretty }}.zip) 
+          echo Binary name: $binary_name
+          echo "binary_name=$binary_name" >> $GITHUB_OUTPUT
+      
+      - name: Generate release folder path
+        id: release_folder
+        run: |
+          release_folder=$(echo target/${{ inputs.target_toolchain }}/release) 
+          echo Release folder: $release_folder
+          echo "release_folder=$release_folder" >> $GITHUB_OUTPUT
+
+  build:
+    runs-on: ${{ needs.os_info.outputs.runs_on_os_name }}
+    name: Build artifact
+    needs:
+      - os_info
+      - build_variables
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Install Rust toolchain and dependencies
+        run: rustup target add ${{ inputs.target_toolchain }}
+
+      - name: Build for ${{ needs.os_info.outputs.os_name_pretty }}
+        run: cargo build --release --target ${{ inputs.target_toolchain }}
+          
+      - name: Zip binary (Windows)
+        if: needs.os_info.outputs.os_name == 'windows'
+        run: |
+          mkdir dist
+          echo "=== Release folder contents ==="
+          dir ${{ needs.build_variables.outputs.release_folder }}
+          echo "=== Zipping binary ==="
+          tar.exe -a -c -f ${{ needs.build_variables.outputs.release_folder }}\${{ needs.build_variables.outputs.binary_name }} -C ${{ needs.build_variables.outputs.release_folder }} zipsource.exe
+
+      - name: Zip binary (Linux/MacOS)
+        if: needs.os_info.outputs.os_name != 'windows'
+        run: |
+          mkdir -v -p dist
+          echo "=== Release folder contents ==="
+          ls -la ${{ needs.build_variables.outputs.release_folder }}
+          echo "=== Zipping binary ==="
+          zip -j ${{ needs.build_variables.outputs.release_folder }}/${{ needs.build_variables.outputs.binary_name }} ${{ needs.build_variables.outputs.release_folder }}/zipsource
+
+      - name: Move zipped binary
+        run: mv -v ${{ needs.build_variables.outputs.release_folder }}/${{ needs.build_variables.outputs.binary_name }} dist/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.build_variables.outputs.binary_name }}
+          path: dist/${{ needs.build_variables.outputs.binary_name }}
+          if-no-files-found: error


### PR DESCRIPTION
The purposes of this build and release pipeline on this project are:

- Automate the release process by exempting the developers from having to manually create a binary for each supported OS by delegating this job to the CI.
- Allow building MacOS-compatible binaries (because I don't own a Mac system to do this) (original issue: https://github.com/SecretX33/ZipSource/issues/1).